### PR TITLE
feat: extend roadmap with 10 jalons

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,13 +1,67 @@
-# Roadmap Orga.com
+# ROADMAP Orga.com (source de verite)
 
-## Phase 0: Bootstrap
-- Initialisation du depot, docs et scripts PowerShell stubs.
+VISION
+- Orga.com: gestion missions/plannings, equipes tech, notifications, exports.
+- Priorite: qualite, securite, Windows-first, CI verte.
 
-## Phase 1: Backend MVP
-- API FastAPI, schema Postgres, auth basique.
+## Jalon 0 - Bootstrap
+- Scaffolding dossiers, docs, scripts stubs, .env.example, .gitignore.
+- CI minimale en place (lint + tests a vide).
 
-## Phase 2: Frontend MVP
-- React + Vite + TS, vues planning.
+## Jalon 1 - Backend base
+- FastAPI squelette /api/v1/health, config env, logs JSON (request_id).
+- Tests pytest (health OK/KO), ruff, mypy. Alembic init. pip-audit.
 
-## Phase 3: CI/CD & Observabilite
-- Pipeline complete, logs/traces, surveillance basique.
+## Jalon 2 - Frontend base
+- Vite + React + TS, page /health (ping backend).
+- Lint, typecheck stricts. npm audit.
+- UI placeholder (tailwind, shadcn).
+
+## Jalon 3 - Authentification v1
+- JWT, refresh token, password hashing (bcrypt).
+- CRUD utilisateurs. Rate limit de base.
+- Tests auth (login ok/ko, refresh ok/ko).
+
+## Jalon 4 - Missions v1
+- Modeles mission, role, site. CRUD REST.
+- Pagination par defaut (limit/offset, total).
+- Tests (create ok/ko, list, pagination).
+
+## Jalon 5 - Disponibilites et Planning
+- Calendrier utilisateur. CRUD disponibilites.
+- Detection conflits de planning.
+- Export ICS (par utilisateur).
+- Tests (chevauchements, exports).
+
+## Jalon 6 - Notifications
+- Email SMTP (demo avec Mailhog) et Telegram bot.
+- Mode debug local. Tests unitaires mocks.
+- Audit log des envois.
+
+## Jalon 7 - Comptabilite simplifiee
+- Modeles cachet, facture.
+- Exports CSV/PDF. ICS pour rappel de paiement.
+- Tests (export ok, format ko).
+
+## Jalon 8 - Observabilite
+- Logs JSON partout (request_id).
+- Metrics Prometheus (latence, requetes).
+- Dashboard Grafana basique.
+- Smoke tests observabilite.
+
+## Jalon 9 - Performance et scalabilite
+- k6 smoke, objectif 1000 VUs p95 < 500ms.
+- Pgbouncer profil prod.
+- SQLAlchemy pool config (pool_size=20, max_overflow=40).
+
+## Jalon 10 - Livraison et gouvernance
+- CHANGELOG, RELEASE.md.
+- PR template, CODEOWNERS, CONTRIBUTING.md.
+- Audit deps (pip-audit, npm audit) en CI bloquant.
+- chore: deps monthly.
+
+Regles:
+- PR <= 300 lignes (hors lockfiles). Conventional Commits.
+- TZ UTC. Pas de secrets en repo.
+- Source de verite: ce document. Si conflit: proposer patch dans PR.
+


### PR DESCRIPTION
## Summary
- expand project roadmap with 10 detailed jalons for backend, frontend, auth, missions, planning, notifications, comptabilite, observabilite, performance, and livraison

## Testing
- `pwsh ./scripts/dev_up.ps1`
- `pwsh ./scripts/smoke.ps1`
- `pwsh ./scripts/test.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68acc2b445388330afc3c6a5ce229498